### PR TITLE
WRISTBAND-40 Allow MONGO_URI to be overriden from environment

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -81,7 +81,7 @@ DATABASES = {
 # MONGO
 # -----------------------------------------------------------------------------
 
-MONGO_DBNAME = env('MONGO_DB_NAME', default='wristband')
+MONGO_DB_NAME = env('MONGO_DB_NAME', default='wristband')
 MONGO_USER = env('MONGODB_USER', default='')
 MONGO_PASSWORD = env('MONGODB_PASSWORD', default='')
 MONGO_HOST = env('MONGODB_HOST', default='localhost')
@@ -92,14 +92,14 @@ if MONGO_USER and MONGO_PASSWORD:
     MONGO_CREDENTIALS = '{username}:{password}@'.format(username=MONGO_USER,
                                                         password=MONGO_PASSWORD)
 
-MONGO_URI = 'mongodb://{credentials}{host}:{port}/{db_name}'.format(
+MONGO_URI = env('MONGO_URI', default='mongodb://{credentials}{host}:{port}/{db_name}'.format(
     credentials=MONGO_CREDENTIALS,
     host=MONGO_HOST,
-    db_name=MONGO_DBNAME,
+    db_name=MONGO_DB_NAME,
     port=MONGO_PORT
-)
+))
 
-mongoengine.connect(MONGO_DBNAME, host=MONGO_URI)
+mongoengine.connect(MONGO_DB_NAME, host=MONGO_URI)
 
 # SESSION
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
We need to override this to connect to our replica set. We could add
an envvar for URI parameters but it's simpler to override the whole
URI.

Also make the `MONGO_DB_NAME` envvar the same in env and in config, which
is in line with other MongoDB libs like PyMongo.