### PR TITLE
WRISTBAND-47 LDAP config fixup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,30 +29,31 @@ It has been deployed successfully with both Gunicorn/Nginx and even uWSGI/Nginx.
 
 For configuration purposes, the following table maps the 'wristband' environment variables to their Django setting:
 
-======================================= =========================== ============================================== ======================================================================
-Environment Variable                    Django Setting              Development Default                            Production Default
-======================================= =========================== ============================================== ======================================================================
-DJANGO_DEBUG                            DEBUG                       True                                           False
-DJANGO_SECRET_KEY                       SECRET_KEY                  CHANGEME!!!                                    raises error
-DJANGO_SECURE_BROWSER_XSS_FILTER        SECURE_BROWSER_XSS_FILTER   n/a                                            True
-DJANGO_SECURE_CONTENT_TYPE_NOSNIFF      SECURE_CONTENT_TYPE_NOSNIFF n/a                                            True
-DJANGO_SECURE_FRAME_DENY                SECURE_FRAME_DENY           n/a                                            True
-DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS   HSTS_INCLUDE_SUBDOMAINS     n/a                                            True
-DJANGO_SESSION_COOKIE_HTTPONLY          SESSION_COOKIE_HTTPONLY     n/a                                            True
-DJANGO_SESSION_COOKIE_SECURE            SESSION_COOKIE_SECURE       n/a                                            False
+===================================== =========================== =================== ==================
+Environment Variable                  Django Setting              Development Default Production Default
+===================================== =========================== =================== ==================
+DJANGO_DEBUG                          DEBUG                       True                False
+DJANGO_SECRET_KEY                     SECRET_KEY                  CHANGEME!!!         raises error
+DJANGO_SECURE_BROWSER_XSS_FILTER      SECURE_BROWSER_XSS_FILTER   n/a                 True
+DJANGO_SECURE_CONTENT_TYPE_NOSNIFF    SECURE_CONTENT_TYPE_NOSNIFF n/a                 True
+DJANGO_SECURE_FRAME_DENY              SECURE_FRAME_DENY           n/a                 True
+DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS HSTS_INCLUDE_SUBDOMAINS     n/a                 True
+DJANGO_SESSION_COOKIE_HTTPONLY        SESSION_COOKIE_HTTPONLY     n/a                 True
+DJANGO_SESSION_COOKIE_SECURE          SESSION_COOKIE_SECURE       n/a                 False
 MONGO_DB_NAME
-======================================= =========================== ============================================== ======================================================================
+===================================== =========================== =================== ==================
 
 App specific environment variables
 
-======================================= =========================== ============================================== ======================================================================
-Environment Variable                    Django Setting              Development Default                            Production Default
-======================================= =========================== ============================================== ======================================================================
-STAGES                                  STAGES                      qa,staging                                     qa,staging
-RELEASES_APP_URI                        RELEASES_APP_URI            http://example.com/apps
-LDAP_URI                                AUTH_LDAP_SERVER_URI        ldap://example.com                             n/a
-LDAP_USER_DN_TEMPLATE                   AUTH_LDAP_USER_DN_TEMPLATE  uid={user},dc=example,dc=com                   n/a
-======================================= =========================== ============================================== ======================================================================
+===================================== ===================================== ======================= ==================
+Environment Variable                  Django Setting                        Development Default     Production Default
+===================================== ===================================== ======================= ==================
+STAGES                                STAGES                                qa,staging              qa,staging
+RELEASES_APP_URI                      RELEASES_APP_URI                      http://example.com/apps
+AUTH_LDAP_SERVER_URI                  AUTH_LDAP_SERVER_URI
+AUTH_LDAP_USER_DN_TEMPLATE            AUTH_LDAP_USER_DN_TEMPLATE
+AUTH_LDAP_BIND_AS_AUTHENTICATING_USER AUTH_LDAP_BIND_AS_AUTHENTICATING_USER False                     False
+===================================== ===================================== ======================= ==================
 
 Getting up and running
 ----------------------

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -200,8 +200,9 @@ AUTHENTICATION_BACKENDS = (
 
 AUTH_USER_MODEL = 'mongo_auth.MongoUser'
 
-AUTH_LDAP_SERVER_URI = env('LDAP_URI', default='ldap://example.com')
-AUTH_LDAP_USER_DN_TEMPLATE = env('LDAP_USER_DN_TEMPLATE', default='uid={user},dc=example,dc=com')
+AUTH_LDAP_SERVER_URI = env('AUTH_LDAP_SERVER_URI', default='')
+AUTH_LDAP_USER_DN_TEMPLATE = env('AUTH_LDAP_USER_DN_TEMPLATE', default='')
+AUTH_LDAP_BIND_AS_AUTHENTICATING_USER = env('AUTH_LDAP_BIND_AS_AUTHENTICATING_USER', default=False)
 
 # REST FRAMEWORK SETTINGS
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Right now there's no strong reason to make the environment variables different
to the constants looked up by Django. Also removing the default values as they
don't add anything, unless we want to send LDAP requests to the real example.com
(93.184.216.34). :)