### PR TITLE
change 403 to 401

### DIFF
--- a/wristband/authentication/tests/test_views.py
+++ b/wristband/authentication/tests/test_views.py
@@ -28,7 +28,7 @@ def test_login_view_bad_credential(mocked_authenticate, rf):
     mocked_authenticate.assert_called_with(username='test_user', password='password')
     assert 'message' in response.content
     assert isinstance(response, JsonResponse)
-    assert response.status_code == 403
+    assert response.status_code == 401
 
 
 def test_login_view_wrong_method(client):

--- a/wristband/authentication/views.py
+++ b/wristband/authentication/views.py
@@ -17,7 +17,7 @@ def login_view(request):
         status = 200
     else:
         data = {'message': 'Invalid credential details'}
-        status = 403 #forbidden
+        status = 401 #forbidden
     return JsonResponse(data=data, status=status)
 
 


### PR DESCRIPTION
403 suggests that even with authentication the resource can't be accessed, a 401 is a better status