### PR TITLE
change message to details in login error

### DIFF
--- a/wristband/authentication/tests/test_views.py
+++ b/wristband/authentication/tests/test_views.py
@@ -26,7 +26,7 @@ def test_login_view_bad_credential(mocked_authenticate, rf):
     request = rf.post(url, {'username': 'test_user', 'password': 'password'})
     response = login_view(request)
     mocked_authenticate.assert_called_with(username='test_user', password='password')
-    assert 'message' in response.content
+    assert 'details' in response.content
     assert isinstance(response, JsonResponse)
     assert response.status_code == 401
 

--- a/wristband/authentication/views.py
+++ b/wristband/authentication/views.py
@@ -16,7 +16,7 @@ def login_view(request):
         data = {'session_key': request.session.session_key}
         status = 200
     else:
-        data = {'message': 'Invalid credential details'}
+        data = {'details': 'Invalid credential details'}
         status = 401 #forbidden
     return JsonResponse(data=data, status=status)
 


### PR DESCRIPTION
This is to be consistent with raised exceptions for more generic handling upstream